### PR TITLE
relocate rockstar popup

### DIFF
--- a/rockstar/rockstar.css
+++ b/rockstar/rockstar.css
@@ -3,7 +3,7 @@
     position: absolute; 
     z-index: 1000; 
     left: 4px; 
-    top: 4px; 
+    bottom: 4px; 
     background-color: white; 
     padding: 8px; 
     border: 1px solid #ddd;


### PR DESCRIPTION
Moves the main rockstar popup to the bottom left corner of the browser window. 
Addresses Issue #12 .
Other popups, such as 'API Explorer', still display in the upper left corner.