### PR TITLE
Add Group Name to ExportAppUsers

### DIFF
--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -545,7 +545,7 @@
         } else if (appId = getAppId()) {
             const atos = a => a ? a.join(";") : "";
             createDiv("Export App Users", mainPopup, function () {
-                startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles,groupNames", 
+                startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles,groupName", 
                     appUser => toCSV(appUser.id, appUser.credentials ? appUser.credentials.userName : "", appUser.scope, appUser.externalId, 
                         appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles), appUser._links.group?.name));
             });

--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -545,9 +545,9 @@
         } else if (appId = getAppId()) {
             const atos = a => a ? a.join(";") : "";
             createDiv("Export App Users", mainPopup, function () {
-                startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles,GroupName", 
+                startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles,groupNames", 
                     appUser => toCSV(appUser.id, appUser.credentials ? appUser.credentials.userName : "", appUser.scope, appUser.externalId, 
-                        appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles), atos(appUser._links.group.name)));
+                        appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles), appUser._links.group?.name));
             });
             createDiv("Export App Groups", mainPopup, function () {
                 startExport("App Groups", `/api/v1/apps/${appId}/groups?expand=group`, 

--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -545,9 +545,9 @@
         } else if (appId = getAppId()) {
             const atos = a => a ? a.join(";") : "";
             createDiv("Export App Users", mainPopup, function () {
-                startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles", 
+                startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles,GroupName", 
                     appUser => toCSV(appUser.id, appUser.credentials ? appUser.credentials.userName : "", appUser.scope, appUser.externalId, 
-                        appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles)));
+                        appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles), atos(appUser._links.group.name));
             });
             createDiv("Export App Groups", mainPopup, function () {
                 startExport("App Groups", `/api/v1/apps/${appId}/groups?expand=group`, 

--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -547,7 +547,7 @@
             createDiv("Export App Users", mainPopup, function () {
                 startExport("App Users", `/api/v1/apps/${appId}/users?limit=500`, "id,userName,scope,externalId,firstName,lastName,syncState,salesforceGroups,samlRoles,GroupName", 
                     appUser => toCSV(appUser.id, appUser.credentials ? appUser.credentials.userName : "", appUser.scope, appUser.externalId, 
-                        appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles), atos(appUser._links.group.name));
+                        appUser.profile.firstName, appUser.profile.lastName, appUser.syncState, atos(appUser.profile.salesforceGroups), atos(appUser.profile.samlRoles), atos(appUser._links.group.name)));
             });
             createDiv("Export App Groups", mainPopup, function () {
                 startExport("App Groups", `/api/v1/apps/${appId}/groups?expand=group`, 


### PR DESCRIPTION
This exports the Group name for users assigned an app via a group to the `Export App Users` function

When an application is assigned via multiple groups, a user will may be in some or all of those multiple groups. This change would export the group via which each user is assigned the app.

Note: this should also help identify groups which, are assigned to an app, however, none of their members are actually getting assigned the app -because they belong to a higher priority group. These groups can, therefore, be removed from the app assignment.

(2nd attempt)