### PR TITLE
Add snippet for cloning app kids

### DIFF
--- a/snippets/clone-source-app-kid-to-target-app.js
+++ b/snippets/clone-source-app-kid-to-target-app.js
@@ -41,16 +41,8 @@
     async function updateTargetAppPrimaryKid(sourceApp, targetApp) {
         const url = '/api/v1/apps/' + targetApp.id;
         console.log(url);
-        const body = JSON.stringify({
-            name: targetApp.name,
-            label: targetApp.label,
-            signOnMode: targetApp.signOnMode,
-            credentials: {
-                signing: {
-                    kid: sourceApp.credentials.signing.kid
-                }
-            }
-        });
+        targetApp.credentials.signing.kid = sourceApp.credentials.signing.kid
+        const body = JSON.stringify(targetApp);
         const r = await fetch(url, {
             method: 'put',
             headers,

--- a/snippets/clone-source-app-kid-to-target-app.js
+++ b/snippets/clone-source-app-kid-to-target-app.js
@@ -1,4 +1,9 @@
 (async function() {
+    var targetAppId = prompt("Enter the target application id");
+    if (targetAppId == "") {
+        alert("No value provided");
+        return;
+    }
     const headers = {
         'accept': 'application/json',
         'content-type': 'application/json',
@@ -6,20 +11,11 @@
     };
 
     const appId = getAppId();     // getAppId from URL like how Rockstar does it
-    const app = await getApp(appId);
+    const sourceApp = await getApp(appId);
+    const targetApp = await getApp(targetAppId)
 
-    while (true) { // prompt for target application id
-        var targetAppId = prompt("Enter the target application id");
-        if (targetAppId) {
-            break;
-        } else if (targetAppId == "") {
-            alert("No value provided");
-            return;
-        }
-    }
-    
-    postAppKidToTarget(app, targetAppId);     // Clone source app primary kid to target app
-    updateTargetAppPrimaryKid(app, targetAppId);     // Switch target app primary kid to source app primary kid
+    postSourceAppKidToTarget(sourceApp, targetApp);     // Clone source app primary kid to target app
+    updateTargetAppPrimaryKid(sourceApp, targetApp);     // Switch target app primary kid to source app primary kid
 
     async function getApp(appId) {
         const url = '/api/v1/apps/' + appId;
@@ -30,8 +26,8 @@
         return app
     }
 
-    async function postAppKidToTarget(app, targetAppId) {
-        const url = '/api/v1/apps/' + app.id + '/credentials/keys/' + app.credentials.signing.kid + '/clone?targetAid=' + targetAppId;
+    async function postSourceAppKidToTarget(sourceApp, targetApp) {
+        const url = '/api/v1/apps/' + sourceApp.id + '/credentials/keys/' + sourceApp.credentials.signing.kid + '/clone?targetAid=' + targetApp.id;
         console.log(url);
         const r = await fetch(url, {
             method: 'post',
@@ -42,16 +38,16 @@
         console.log(clone);
     }
 
-    async function updateTargetAppPrimaryKid(app, targetAppId) {
-        const url = '/api/v1/apps/' + targetAppId;
+    async function updateTargetAppPrimaryKid(sourceApp, targetApp) {
+        const url = '/api/v1/apps/' + targetApp.id;
         console.log(url);
         const body = JSON.stringify({
-            name: app.name,
-            signOnMode: app.signOnMode,
-            settings: app.settings,
+            name: targetApp.name,
+            label: targetApp.label,
+            signOnMode: targetApp.signOnMode,
             credentials: {
                 signing: {
-                    kid: app.credentials.signing.kid
+                    kid: sourceApp.credentials.signing.kid
                 }
             }
         });

--- a/snippets/clone-source-app-kid-to-target-app.js
+++ b/snippets/clone-source-app-kid-to-target-app.js
@@ -1,0 +1,77 @@
+(async function() {
+    const headers = {
+        'accept': 'application/json',
+        'content-type': 'application/json',
+        'X-Okta-XsrfToken': document.querySelector('#_xsrfToken').innerText
+    };
+
+    const appId = getAppId();     // getAppId from URL like how Rockstar does it
+    const app = await getApp(appId);
+
+    while (true) { // prompt for target application id
+        var targetAppId = prompt("Enter the target application id");
+        if (targetAppId) {
+            break;
+        } else if (targetAppId == "") {
+            alert("No value provided");
+            return;
+        }
+    }
+    
+    postAppKidToTarget(app, targetAppId);     // Clone source app primary kid to target app
+    updateTargetAppPrimaryKid(app, targetAppId);     // Switch target app primary kid to source app primary kid
+
+    async function getApp(appId) {
+        const url = '/api/v1/apps/' + appId;
+        console.log(url);
+        const r = await fetch(url);
+        console.log(r.ok, r.status);
+        const app = await r.json();
+        return app
+    }
+
+    async function postAppKidToTarget(app, targetAppId) {
+        const url = '/api/v1/apps/' + app.id + '/credentials/keys/' + app.credentials.signing.kid + '/clone?targetAid=' + targetAppId;
+        console.log(url);
+        const r = await fetch(url, {
+            method: 'post',
+            headers
+        });
+        console.log(r.ok, r.status);
+        const clone = await r.json();
+        console.log(clone);
+    }
+
+    async function updateTargetAppPrimaryKid(app, targetAppId) {
+        const url = '/api/v1/apps/' + targetAppId;
+        console.log(url);
+        const body = JSON.stringify({
+            name: app.name,
+            signOnMode: app.signOnMode,
+            settings: app.settings,
+            credentials: {
+                signing: {
+                    kid: app.credentials.signing.kid
+                }
+            }
+        });
+        const r = await fetch(url, {
+            method: 'put',
+            headers,
+            body
+        });
+        console.log(r.ok, r.status);
+        const update = await r.json();
+        console.log(update);
+    }
+
+    // from Rockstar https://github.com/gabrielsroka/gabrielsroka.github.io/blob/master/rockstar/rockstar.js#L767
+    function getAppId() {
+        var path = location.pathname;
+        var pathparts = path.split('/');
+        if (path.match("admin/app") && (pathparts.length == 6 || pathparts.length == 7)) {
+            return pathparts[5];
+        }
+    }
+}
+)();


### PR DESCRIPTION
This snippet is used for when you need to share application key credentials across different apps, you might do this so you can have a 2nd saml app used to login into service accounts.

API ref https://developer.okta.com/docs/guides/sharing-cert/main/

Tested working with Google Workspace and AWS IAM Centre OIN apps