### PR TITLE
Fix exception while exporting big data set.

### DIFF
--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -702,9 +702,9 @@
                 var object = objects[i];
                 var line = template(object);
                 if (line.then) {
-                    line.then(ln => lines.push(ln));
+                    line.then(ln => lines.push(ln + "\n"));
                 } else {
-                    lines.push(line);
+                    lines.push(line + "\n");
                     totalBytes += line.length + 1;
                 }
             }
@@ -1244,8 +1244,9 @@
     }
     function downloadCSV(popup, html, header, lines, filename) {
         popup.html(html + "Done.");
+        lines.unshift(header + "\n");
         var a = $("<a>").appendTo(popup);
-        a.attr("href", URL.createObjectURL(new Blob([header + "\n" + lines.join("\n")], {type: 'text/csv'})));
+        a.attr("href", URL.createObjectURL(new Blob(lines, {type: 'text/csv'})));
         var date = (new Date()).toISOString().replace(/T/, " ").replace(/:/g, "-").slice(0, 19);
         a.attr("download", `${filename} ${date}.csv`);
         a[0].click();


### PR DESCRIPTION
For a huge amount of exported records doing lines.join("\n") could cause an exception:

```
caught RangeError: Invalid string length
    at Array.join (<anonymous>)
    at downloadCSV (rockstar.js:1248:76)
    at Object.getObjects (rockstar.js:739:21)
    at Object.<anonymous> (jquery-1.12.4.min.PATCHED.js:2:28659)
    at i (jquery-1.12.4.min.PATCHED.js:2:27345)
    at Object.fireWith [as resolveWith] (jquery-1.12.4.min.PATCHED.js:2:28104)
    at x (jquery-1.12.4.min.PATCHED.js:4:22488)
    at XMLHttpRequest.c (jquery-1.12.4.min.PATCHED.js:4:26689)
 ```

This PR removes lines.join and put `\n` on each line during `getObjects`.