### PR TITLE
Implement "execute" and a few bug fixes

### DIFF
--- a/wozmon/wozmon.c
+++ b/wozmon/wozmon.c
@@ -61,7 +61,7 @@ int main() { // with help from ChatGPT 3.5
         printf("\n"); // getline
         fgets(in, sizeof(in), stdin); // nextchar
         int y = 0;
-        char mode = 'x'; // setmode, x=xam, b=block, s=store
+        char mode = 'x'; // setmode, x=xam, b=block, s=store, r=run
         while (in[y] != '\0') {
             char c = in[y]; // nextitem
             if (c < '.') y++; // blskip-ish
@@ -71,8 +71,10 @@ int main() { // with help from ChatGPT 3.5
             } else if (c == ':') {
                 mode = 's';
                 y++;
-            } else if (c == 'r') break; // run, not implemented
-            else {
+            } else if (c == 'r') { // run
+                mode = 'r';
+                y++;
+            } else {
                 int hx = 0;
                 int ysav = y;
                 while (in[y] != '\0') {
@@ -95,6 +97,10 @@ int main() { // with help from ChatGPT 3.5
                 if (mode == 'x') { // notstor
                     st = hx; // setadr
                     xam = hx;
+                }
+                if (mode == 'r') { // run
+                    void (*fn)(void) = (void(*)(void))(mem + hx);
+                    fn();
                 }
                 bool addr = true;
                 while (true) {

--- a/wozmon/wozmon.c
+++ b/wozmon/wozmon.c
@@ -78,7 +78,8 @@ int main() { // with help from ChatGPT 3.5
                 while (in[y] != '\0') {
                     char c = in[y]; // nexthex
                     if (isdigit(c) || (c >= 'a' && c <= 'f')) {
-                        hx = hx * 16 + strtol(&c, NULL, 16); // dig
+                        char s[] = {c, 0};
+                        hx = hx * 16 + strtol(s, NULL, 16); // dig
                     } else break;
                     y++;
                 }

--- a/wozmon/wozmon.c
+++ b/wozmon/wozmon.c
@@ -59,7 +59,8 @@ int main() { // with help from ChatGPT 3.5
             escape = false;
         }
         printf("\n"); // getline
-        fgets(in, sizeof(in), stdin); // nextchar
+        if (!fgets(in, sizeof(in), stdin))
+           break;
         int y = 0;
         char mode = 'x'; // setmode, x=xam, b=block, s=store, r=run
         while (in[y] != '\0') {


### PR DESCRIPTION
Hello, I just commented on your HN comment about this.

1. Use VirtualAlloc on Windows, or mmap(2) on Unix, to ask for executable pages.  Otherwise, your process will crash when jumping into the memory buffer.
2. Implement run by interpreting the memory address as a function pointer and calling it.
3. While doing this I noticed ChatGPT did not do the hexadecimal parse correctly.  Fix that.
4. Make EOF exit the program gracefully.