### PR TITLE
Fix opening settings popup when clicking the restore button

### DIFF
--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -1123,7 +1123,7 @@
         btnRestore.onclick = async function () {
             var baseUrl = localStorage.backuptaBaseUrl;
             if (!baseUrl) {
-                await openConfigPopup(true);
+                await settings();
                 return;
             }
             var items = document.querySelectorAll(".data-list-table.rockstar input[type='checkbox']:checked");


### PR DESCRIPTION
* If no backupta base URL is configured, clicking the restore button should open the settings popup. However the name of the settings function was changed but not its call.