### PR TITLE
Add new recycle bin options for Security and Workflow events

### DIFF
--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -35,6 +35,69 @@
             searchPlaceholder: "Search app...",
             oktaFilter: 'eventType eq "application.lifecycle.delete"',
             backuptaFilterBy: 'type:DELETE;component:APPS',
+        },
+        deletedIdPs: {
+            menuTitle: 'Deleted Identity Providers',
+            title: "Latest deleted identity providers",
+            searchPlaceholder: "Search IdP...",
+            oktaFilter: 'eventType eq "system.idp.lifecycle.delete"',
+            backuptaFilterBy: 'type:DELETE;component:IDPS',
+        },
+        deletedAuthenticators: {
+            menuTitle: 'Deleted Authenticators',
+            title: "Latest deleted authenticators",
+            searchPlaceholder: "Search authenticator...",
+            oktaFilter: 'eventType eq "security.authenticator.lifecycle.deactivate"',
+            backuptaFilterBy: 'type:UPDATE;component:AUTHENTICATORS',
+        },
+        deletedAuthenticationPolicies: {
+            menuTitle: 'Deleted Authentication Policies',
+            title: "Latest deleted authentication policies",
+            searchPlaceholder: "Search policy...",
+            oktaFilter: 'eventType eq "policy.lifecycle.delete" and target.detailEntry.policyType eq "Okta:SignOn"',
+            backuptaFilterBy: 'type:DELETE;component:AUTHENTICATION_POLICIES',
+        },
+        deletedGlobalSessionPolicies: {
+            menuTitle: 'Deleted Global Session Policies',
+            title: "Latest deleted global session policies",
+            searchPlaceholder: "Search policy...",
+            oktaFilter: 'eventType eq "policy.lifecycle.delete" and target.detailEntry.policyType eq "OktaSignOn"',
+            backuptaFilterBy: 'type:DELETE;component:SIGN_ON_POLICIES',
+        },
+        deletedProfileEnrollments:{
+            menuTitle: 'Deleted Profile Enrollments',
+            title: "Latest deleted profile enrollments",
+            searchPlaceholder: "Search profile enrollments...",
+            oktaFilter: 'eventType eq "policy.lifecycle.delete" and target.detailEntry.policyType eq "Okta:ProfileEnrollment"',
+            backuptaFilterBy: 'type:DELETE;component:PROFILE_ENROLLMENT_POLICIES',
+        },
+        deletedNetworks: {
+            menuTitle: 'Deleted Networks',
+            title: "Latest deleted networks",
+            searchPlaceholder: "Search network...",
+            oktaFilter: 'eventType eq "zone.delete"',
+            backuptaFilterBy: 'type:DELETE;component:NETWORK_ZONES',
+        },
+        deletedAPIAuthorizationServers: {
+            menuTitle: 'Deleted API Authorization Servers',
+            title: "Latest deleted API authorization servers",
+            searchPlaceholder: "Search server...",
+            oktaFilter: 'eventType eq "oauth2.as.deleted"',
+            backuptaFilterBy: 'type:DELETE;component:AUTHORIZATION_SERVERS',
+        },
+        deletedWorkflowInlineHooks: {
+            menuTitle: 'Deleted Workflow Inline Hooks',
+            title: "Latest deleted workflow inline hooks",
+            searchPlaceholder: "Search hook...",
+            oktaFilter: 'eventType eq "inline_hook.deleted"',
+            backuptaFilterBy: 'type:DELETE;component:INLINE_HOOKS',
+        },
+        deletedWorkflowEventHooks: {
+            menuTitle: 'Deleted Workflow Event Hooks',
+            title: "Latest deleted workflow event hooks",
+            searchPlaceholder: "Search hook...",
+            oktaFilter: 'eventType eq "event_hook.deleted"',
+            backuptaFilterBy: 'type:DELETE;component:EVENT_HOOKS',
         }
     };
 
@@ -81,6 +144,32 @@
             openLogList('deletedGroups');
         } else if (location.pathname == "/admin/apps/active") {
             openLogList('deletedApps');
+        } else if (location.pathname == "/admin/access/identity-providers") {
+            openLogList('deletedIdPs');
+        } else if (location.pathname == "/admin/access/multifactor") {
+            isOIE().then(isOIE => {
+                if (isOIE) {
+                    openLogList('deletedAuthenticators');
+                }
+            })
+        } else if (location.pathname == "/admin/authn/authentication-policies") {
+            openLogList('deletedAuthenticationPolicies');
+        } else if (location.pathname == "/admin/access/policies") {
+            isOIE().then(isOIE => {
+                if (isOIE) {
+                    openLogList('deletedGlobalSessionPolicies');
+                }
+            })
+        } else if (location.pathname == "/admin/authn/policies") {
+            openLogList('deletedProfileEnrollments');
+        } else if (location.pathname == "/admin/access/networks") {
+            openLogList('deletedNetworks');
+        } else if (location.pathname == "/admin/oauth2/as") {
+            openLogList('deletedAPIAuthorizationServers');
+        } else if (location.pathname == "/admin/workflow/inlinehooks") {
+            openLogList('deletedWorkflowInlineHooks');
+        } else if (location.pathname == "/admin/workflow/eventhooks") {
+            openLogList('deletedWorkflowEventHooks');
         }
 
         apiExplorer();
@@ -1306,6 +1395,10 @@
     if ($) {
         var xsrf = $("#_xsrfToken");
         if (xsrf.length) $.ajaxSetup({headers: {"X-Okta-XsrfToken": xsrf.text()}});
+    }
+    async function isOIE() {
+        let data = await getJSON("/.well-known/okta-organization");
+        return data.pipeline === "idx"
     }
     function createPopup(title, main) {
         function toggleClosed() {

--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -51,9 +51,9 @@
             backuptaFilterBy: 'type:UPDATE;component:AUTHENTICATORS',
         },
         deletedAuthenticatorsClassic: {
-            menuTitle: 'Deleted Authenticators',
-            title: "Latest deleted authenticators",
-            searchPlaceholder: "Search authenticator...",
+            menuTitle: 'Deleted Multifactor Policies',
+            title: "Latest deleted multifactor policies",
+            searchPlaceholder: "Search multifactor policies...",
             oktaFilter: 'eventType eq "policy.lifecycle.delete" and target.detailEntry.policyType eq "OktaMfaEnroll"',
             backuptaFilterBy: 'type:DELETE;component:MFA_ENROLL_POLICIES',
         },
@@ -72,8 +72,8 @@
             backuptaFilterBy: 'type:DELETE;component:SIGN_ON_POLICIES',
         },
         deletedGlobalSessionPoliciesClassic: {
-            menuTitle: 'Deleted Global Session Policies',
-            title: "Latest deleted global session policies",
+            menuTitle: 'Deleted Authentication Policies',
+            title: "Latest deleted authentication policies",
             searchPlaceholder: "Search policy...",
             oktaFilter: 'eventType eq "policy.lifecycle.delete" and (target.detailEntry.policyType eq "Password" or target.detailEntry.policyType eq "OktaSignOn")',
             backuptaFilterBy: 'type:DELETE;component:PASSWORD_POLICIES,SIGN_ON_POLICIES',

--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -50,6 +50,13 @@
             oktaFilter: 'eventType eq "security.authenticator.lifecycle.deactivate"',
             backuptaFilterBy: 'type:UPDATE;component:AUTHENTICATORS',
         },
+        deletedAuthenticatorsClassic: {
+            menuTitle: 'Deleted Authenticators',
+            title: "Latest deleted authenticators",
+            searchPlaceholder: "Search authenticator...",
+            oktaFilter: 'eventType eq "policy.lifecycle.delete" and target.detailEntry.policyType eq "OktaMfaEnroll"',
+            backuptaFilterBy: 'type:DELETE;component:MFA_ENROLL_POLICIES',
+        },
         deletedAuthenticationPolicies: {
             menuTitle: 'Deleted Authentication Policies',
             title: "Latest deleted authentication policies",
@@ -63,6 +70,13 @@
             searchPlaceholder: "Search policy...",
             oktaFilter: 'eventType eq "policy.lifecycle.delete" and target.detailEntry.policyType eq "OktaSignOn"',
             backuptaFilterBy: 'type:DELETE;component:SIGN_ON_POLICIES',
+        },
+        deletedGlobalSessionPoliciesClassic: {
+            menuTitle: 'Deleted Global Session Policies',
+            title: "Latest deleted global session policies",
+            searchPlaceholder: "Search policy...",
+            oktaFilter: 'eventType eq "policy.lifecycle.delete" and (target.detailEntry.policyType eq "Password" or target.detailEntry.policyType eq "OktaSignOn")',
+            backuptaFilterBy: 'type:DELETE;component:PASSWORD_POLICIES,SIGN_ON_POLICIES',
         },
         deletedProfileEnrollments:{
             menuTitle: 'Deleted Profile Enrollments',
@@ -150,6 +164,8 @@
             isOIE().then(isOIE => {
                 if (isOIE) {
                     openLogList('deletedAuthenticators');
+                } else {
+                    openLogList('deletedAuthenticatorsClassic');
                 }
             })
         } else if (location.pathname == "/admin/authn/authentication-policies") {
@@ -158,6 +174,8 @@
             isOIE().then(isOIE => {
                 if (isOIE) {
                     openLogList('deletedGlobalSessionPolicies');
+                } else {
+                    openLogList('deletedGlobalSessionPoliciesClassic');
                 }
             })
         } else if (location.pathname == "/admin/authn/policies") {


### PR DESCRIPTION
This pull requests adds a "Deleted XXX" option to the following okta pages

* security > authenticator
* security > authentication policies
* security > global session policies
* security > profile enrollment policies
* security > identity providers
* security > network zone
* security > apis
* workflow > inline hooks
* workflow > event hooks

Clicking "Deleted XXX" will open the usual window with a table listing deleted items, with the ability to select items and click "restore with backupta". This will take the user to the "events" page of backupta, with the items pre-filtered. 

The events from "authenticator", "inline hooks", and "event hooks" will show up in backupta however they are not revertable. All other events are revertable.