### PR TITLE
Add "Select All Bookmark Apps" Deprovisioning Tasks

### DIFF
--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -138,6 +138,8 @@
             activeDirectory();
         } else if (location.pathname == "/admin/access/identity-providers") {
             identityProviders();
+        } else if (location.pathname == "/admin/tasks") {
+            dashboardTasks();
         }
 
         var count = 0;
@@ -571,6 +573,13 @@
                 });
             });
         });      
+    }
+    function dashboardTasks() {
+        createDiv("Select All Bookmark Apps", mainPopup, () => {
+            // Select all checkboxes in rows that contain "Bookmark App"
+            $('li.deprovision-instance-row').has('.task-instance-name:contains("Bookmark App")')
+            .find('.deprovision-instance-row-checkbox').prop('checked', true);
+        });
     }
 
     function exportObjects() {


### PR DESCRIPTION
A majority of my bookmark apps are bookmarks strictly, and have no account to deprovision. It is tedious to find and select all bookmark apps to mark the deprovisioning tasks as completed.  This feature would make it easier for Okta admins to select all deprovisioning task via one-click from the Rockstar popup.

<img width="581" alt="image" src="https://github.com/user-attachments/assets/99304fed-410b-4afe-b9bc-fc548bfffcb9" />
