### PR TITLE
Add toggle button to enable/disable Rockstar automatic popup

### DIFF
--- a/rockstar/manifest.json
+++ b/rockstar/manifest.json
@@ -17,7 +17,8 @@
     "service_worker": "service_worker.js",
     "type": "module"
   },
-  "permissions": ["declarativeContent"],
+  "permissions": ["declarativeContent",
+  "storage"],
   "content_scripts": [
     {
       "matches": [

--- a/rockstar/menu.html
+++ b/rockstar/menu.html
@@ -36,6 +36,12 @@ Network Zones, YubiKeys, Mappings, Admins...
 <li>Many: enhanced menus
 </ul>
 ...and more to come<br>
+<div id="autoPopupToggle" style="padding: 8px; border-top: 1px solid #ccc; border-bottom: 1px solid #ccc; margin-top: 10px;">
+  <label>
+    <input type="checkbox" id="autoPopupCheckbox">
+    Enable automatic popup on page load
+  </label>
+</div>
 <h2>Setup</h2>
 <a href="https://chrome.google.com/webstore/detail/chjepkekmhealpjipcggnfepkkfeimbd" target='_blank' rel='noopener'>rockstar</a> is available on the Chrome 
 Web Store.

--- a/rockstar/menu.js
+++ b/rockstar/menu.js
@@ -1,1 +1,14 @@
 // results.innerText = location.href;
+document.addEventListener('DOMContentLoaded', function () {
+  const checkbox = document.getElementById('autoPopupCheckbox');
+
+  // Load stored value (default: true)
+  chrome.storage.local.get({ autoPopup: true }, function (result) {
+    checkbox.checked = result.autoPopup;
+  });
+
+  // Save new value on change
+  checkbox.addEventListener('change', function () {
+    chrome.storage.local.set({ autoPopup: checkbox.checked });
+  });
+});

--- a/rockstar/rockstar.js
+++ b/rockstar/rockstar.js
@@ -1,4 +1,11 @@
 (function () {
+        chrome?.storage?.local.get({ autoPopup: true }, function (result) {
+        if (!result.autoPopup) return; // Exit early if popup is disabled
+        continueExecution();
+    });
+    return; // prevent the rest of the script from running until continueExecution is explicitly called
+
+    function continueExecution() {
     // What does rockstar do?
     //   Export Objects to CSV: Users, Groups, Group Members, Directory Users, App Users, App Groups, Apps, App Notes, Network Zones, Admins, etc.
     //   User home page: Show SSO (SAML assertion, etc)
@@ -9,7 +16,6 @@
     //   API: API Explorer, Pretty Print JSON
     //   Many: enhanced menus
     // and more to come...
-
     var mainPopup;
     $ = window.$ || window.jQueryCourage;
     const headers = {'X-Okta-User-Agent-Extended': 'rockstar'};
@@ -1596,4 +1602,5 @@
         });
         return true; // Indicates that sendResponse will be called asynchronously.
     });
+}
 })();


### PR DESCRIPTION
This update adds a UI checkbox to the Rockstar extension menu to control whether the popup appears automatically on Okta admin pages.

-  Default behavior: popup auto-shows (preserved)
-  New toggle: user can disable/enable the popup
-  Preference is saved via `chrome.storage.local` and persists across sessions
-  Early-exit logic added to `rockstar.js` to prevent popup load when disabled

This improves usability for admins who prefer the popup only when explicitly invoked.

![image](https://github.com/user-attachments/assets/339059e5-a99a-4c40-bd1c-5345cbc3d32a)
